### PR TITLE
Added 2 stats to homepage

### DIFF
--- a/components/server-stats.js
+++ b/components/server-stats.js
@@ -10,17 +10,21 @@ export default class ServerStats extends React.Component {
       isLoaded: false,
       guilds: 0,
       activeGames: 0,
+      totalGames: 0,
+      totalUsers: 0,
     };
   }
 
   async fetchData() {
     try {
-      const response = await fetch("https://stats.automute.us/stats/api");
+      const response = await fetch("https://galactus.automute.us/");
       const json = await response.json();
       this.setState({
         isLoaded: true,
         guilds: json.totalGuilds,
         activeGames: json.activeGames,
+        totalGames: json.totalGames,
+        totalUsers: json.totalUsers,
       });
     } catch (error) {
       this.setState({
@@ -42,25 +46,36 @@ export default class ServerStats extends React.Component {
   }
 
   render() {
-    const { error, isLoaded, guilds, activeGames } = this.state;
+    const {
+      error,
+      isLoaded,
+      guilds,
+      activeGames,
+      totalGames,
+      totalUsers,
+    } = this.state;
 
     if (error) {
       return (
         <div
           id="home-stats"
-          className="d-flex align-content-center align-content-lg-start flex-column flex-lg-row"
+          className={`home-stats-wrapper ${styles.home_stats}`}
         >
-          <StatCard label="Servers" stat={"Such"} loaded={true} />
           <StatCard label="Active Games" stat={"Very"} loaded={true} />
+          <StatCard label="Servers" stat={"Such"} loaded={true} />
+          <StatCard label="Users" stat={"Many"} loaded={true} />
+          <StatCard label="Games Muted" stat={"Wow"} loaded={true} />
         </div>
       );
     } else {
       return (
         <div
-          className={`d-flex align-content-center align-content-lg-start flex-column flex-lg-row ${styles.home_stats}`}
+          className={`home-stats-wrapper ${styles.home_stats}`}
         >
           <StatCard label="Servers" stat={guilds} loaded={isLoaded} />
           <StatCard label="Active Games" stat={activeGames} loaded={isLoaded} />
+          <StatCard label="Users" stat={totalUsers} loaded={isLoaded} />
+          <StatCard label="Games Muted" stat={totalGames} loaded={isLoaded} />
         </div>
       );
     }
@@ -71,7 +86,9 @@ function StatCard(props) {
   return (
     <div className={`stat-card p-3 p-lg-5 pb-0 ${styles.stat_card}`}>
       <div className={styles.stat_data}>
-        <div className={props.loaded ? styles.fadeIn : styles.fadeOut}>{props.stat}</div>
+        <div className={props.loaded ? styles.fadeIn : styles.fadeOut}>
+          {props.stat}
+        </div>
       </div>
       <div className={styles.stat_label}>{props.label}</div>
     </div>

--- a/components/server-stats.js
+++ b/components/server-stats.js
@@ -84,7 +84,7 @@ export default class ServerStats extends React.Component {
 
 function StatCard(props) {
   return (
-    <div className={`stat-card p-3 p-lg-5 pb-0 ${styles.stat_card}`}>
+    <div className={`stat-card p-3 pb-0 ${styles.stat_card}`}>
       <div className={styles.stat_data}>
         <div className={props.loaded ? styles.fadeIn : styles.fadeOut}>
           {props.stat}

--- a/components/server-stats.js
+++ b/components/server-stats.js
@@ -2,6 +2,7 @@ import React from "react";
 
 import styles from "./server-stats.module.css";
 
+const StatsURL = "https://stats.automute.us/stats/api"
 export default class ServerStats extends React.Component {
   constructor(props) {
     super(props);
@@ -17,7 +18,7 @@ export default class ServerStats extends React.Component {
 
   async fetchData() {
     try {
-      const response = await fetch("https://galactus.automute.us/");
+      const response = await fetch(StatsURL);
       const json = await response.json();
       this.setState({
         isLoaded: true,

--- a/styles/global.css
+++ b/styles/global.css
@@ -28,7 +28,7 @@ body {
   display: flex;
   flex: 1 0 auto;
   min-height: 100%;
-  overflow-y: hidden;
+  overflow: hidden;
 }
 
 h1,
@@ -207,6 +207,12 @@ h6 {
   outline: 0;
   cursor: pointer;
   border: none;
+}
+
+.home-stats-wrapper {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
 }
 
 /* Small devices (landscape phones, 576px and up) */


### PR DESCRIPTION
Added the "Users" and "Total Games" stats to the home page, as "Users" and "Games Muted", respectively.

NOTE: please DON'T accept this until we update https://galactus.automute.us/ to allow for CORS requests, since the https://stats.automute.us/stats/api page doesn't have the cool new stats.