### PR TITLE
fix: add missing commands in help command

### DIFF
--- a/data/commands.tsx
+++ b/data/commands.tsx
@@ -26,6 +26,8 @@ export const commands: Command[] = [
                     "map",
                     "stats",
                     "premium",
+                    "debug",
+                    "download",
                 ].sort(),
             },
         ],


### PR DESCRIPTION
### Changes
* add `debug` and `download` under `/help`. Related to https://github.com/automuteus/automuteus/pull/492

### Additions
* N/A
