### PR TITLE
Add download/debug command info and tighter Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Install dependencies only when needed
-FROM node:16-alpine AS deps
+FROM node:16-alpine3.16 AS deps 
+# Build errors originating from alpine 3.17 openssl update: https://github.com/prisma/prisma/issues/16834#issuecomment-1355195025
+
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
@@ -7,7 +9,7 @@ COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile
 
 # Rebuild the source code only when needed
-FROM node:16-alpine AS builder
+FROM node:16-alpine3.16 AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
@@ -21,7 +23,7 @@ ENV NEXT_TELEMETRY_DISABLED 1
 RUN yarn build
 
 # Production image, copy all the files and run next
-FROM node:16-alpine AS runner
+FROM node:16-alpine3.16 AS runner
 WORKDIR /app
 
 ENV NODE_ENV production

--- a/data/commands.tsx
+++ b/data/commands.tsx
@@ -271,6 +271,7 @@ export const commands: Command[] = [
     {
         command: "download",
         description: ["Download AutoMuteUs data"],
+        isPremium: true,
         arguments: [
             {
                 name: "category",

--- a/data/commands.tsx
+++ b/data/commands.tsx
@@ -26,6 +26,8 @@ export const commands: Command[] = [
                     "map",
                     "stats",
                     "premium",
+                    "debug",
+                    "download",
                 ].sort(),
             },
         ],

--- a/data/commands.tsx
+++ b/data/commands.tsx
@@ -266,6 +266,26 @@ export const commands: Command[] = [
             },
         ],
     },
+    {
+        command: "download",
+        description: ["Download AutoMuteUs data"],
+        arguments: [
+            {
+                name: "category",
+                description: ["Data to download"],
+                type: "string",
+                level: "required",
+                values: [
+                    "guild",
+                    "users",
+                    "users_games",
+                    "games",
+                    "game_events",
+                ].sort(),
+            },
+        ],
+        example: "download category:games",
+    },
 ];
 
 export const settings: Command[] = [

--- a/data/premium_items.tsx
+++ b/data/premium_items.tsx
@@ -1,4 +1,4 @@
-import {Props as PremiumItemProps} from "../components/premium/PremiumItem"
+import { Props as PremiumItemProps } from "../components/premium/PremiumItem"
 
 import crewmate_brown from "../public/images/svg/crewmate_brown.svg";
 import crewmate_white from "../public/images/svg/crewmate_white.svg";
@@ -55,6 +55,15 @@ export const premium_items: Array<PremiumItemProps> = [
                     />
                 ),
             },
+            {
+                key: "Download Raw Data",
+                value: (
+                    <FontAwesomeIcon
+                        icon={faTimesCircle}
+                        className="text-muted"
+                    />
+                ),
+            },
         ],
     },
     {
@@ -92,6 +101,15 @@ export const premium_items: Array<PremiumItemProps> = [
             },
             {
                 key: "Premium Servers",
+                value: (
+                    <FontAwesomeIcon
+                        icon={faTimesCircle}
+                        className="text-muted"
+                    />
+                ),
+            },
+            {
+                key: "Download Raw Data",
                 value: (
                     <FontAwesomeIcon
                         icon={faTimesCircle}
@@ -142,6 +160,10 @@ export const premium_items: Array<PremiumItemProps> = [
                         <strong className=""> 2</strong>
                     </>
                 ),
+            },
+            {
+                key: "Download Raw Data",
+                value: <FontAwesomeIcon icon={faCheckCircle} />,
             },
         ],
     },

--- a/pages/commands.tsx
+++ b/pages/commands.tsx
@@ -110,6 +110,9 @@ export default function CommandsPage() {
                                                         )
                                                     }
                                                 >
+                                                    {cmd.isPremium && (
+                                                        <>{premium_icon}</>
+                                                    )}{" "}
                                                     <span
                                                         style={{
                                                             fontFamily:

--- a/pages/premium/index.tsx
+++ b/pages/premium/index.tsx
@@ -8,6 +8,7 @@ import { Guild } from "@prisma/client";
 
 import { faDiscord } from "@fortawesome/free-brands-svg-icons";
 import {
+    faDatabase,
     faGamepad,
     faHeadset,
     faMedal,
@@ -225,5 +226,11 @@ const current_perks = [
         description:
             "Get your premium AutoMuteUs bot status in multiple Discord servers!",
         icon: <FontAwesomeIcon size="2x" className="mb-3" icon={faDiscord} />,
+    },
+    {
+        perk: "Download Raw Data",
+        description:
+            "Download the raw data stored in AutoMuteUs's database!",
+        icon: <FontAwesomeIcon size="2x" className="mb-3" icon={faDatabase} />,
     },
 ];


### PR DESCRIPTION
### Changes
* Specified `node:16-alpine3.16` as the base image version in `Dockerfile`
* Fixed commands page to show premium icons for commands in addition to settings
* #52

### Additions
* #51
