### PR TITLE
feat: add unmute sub-command for /debug

### DIFF
--- a/data/commands.tsx
+++ b/data/commands.tsx
@@ -262,6 +262,19 @@ export const commands: Command[] = [
                 example: "debug unmute-all",
             },
             {
+                command: "unmute",
+                description: ["Unmute myself, or a specific user"],
+                example: "debug unmute user:@Yoshirahh",
+                arguments: [
+                    {
+                        name: "user",
+                        level: "optional",
+                        description: ["User who should be unmuted/undeafened"],
+                        type: "Discord @User",
+                    },
+                ],
+            },
+            {
                 command: "view game-state",
                 description: ["Print out the current game state"],
                 example: "debug view game-state",


### PR DESCRIPTION
Closes #57 

### Changes
* N/A

### Additions
* `unmute` sub-command is added for `/debug`
  * 
![image](https://github.com/automuteus/web/assets/2920259/0aa7aeb8-a6ed-429e-b178-93f4a5499d46)

